### PR TITLE
Fix `plot_usmap` column naming error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,16 @@
 # usmap 0.5.2.9999
 
+### Improvements
 * Improve map resolution.
   * More polygons are shown, this has a marginal increase on the data set file sizes but it is negligible.
 * Add shape file update history, see [Issue #30](https://github.com/pdil/usmap/issues/30).
 * Extract map data frame to external [usmapdata](https://github.com/pdil/usmapdata) package to reduce `usmap` package size, see [Issue #39](https://github.com/pdil/usmap/issues/39).
   * All existing functions (including `us_map()`) should continue to work as usual.
+  
+### Bug Fixes
 * Fix CRS warnings, see [Issue #40](https://github.com/pdil/usmap/issues/40).
+* Fix `plot_usmap()` issue when provided data has `"values"` column, see [Issue #48](https://github.com/pdil/usmap/issues/48) and [this Stack Overflow question](https://stackoverflow.com/questions/61111024/trouble-using-plot-usmap-function-in-usmap-package).
+
 
 # usmap 0.5.2
 Released Wednesday, October 7, 2020.

--- a/R/plot-map.R
+++ b/R/plot-map.R
@@ -97,7 +97,7 @@ plot_usmap <- function(regions = c("states", "state", "counties", "county"),
     geom_args[["mapping"]] <- ggplot2::aes(x = x, y = y, group = group)
   } else {
     map_df <- map_with_data(data, values = values, include = include, exclude = exclude)
-    geom_args[["mapping"]] <- ggplot2::aes(x = x, y = y, group = group, fill = map_df[, values])
+    geom_args[["mapping"]] <- ggplot2::aes_string(x = "x", y = "y", group = "group", fill = values)
   }
 
   polygon_layer <- do.call(ggplot2::geom_polygon, geom_args)

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -65,7 +65,7 @@ test_that("layer parameters are correct", {
   expect_equal(deparse(q$layers[[1]]$mapping$x), "~x")
   expect_equal(deparse(q$layers[[1]]$mapping$y), "~y")
   expect_equal(deparse(q$layers[[1]]$mapping$group), "~group")
-  expect_equal(deparse(q$layers[[1]]$mapping$fill), "~map_df[, values]")
+  expect_equal(deparse(q$layers[[1]]$mapping$fill), "~pop_2015")
   expect_equal(as.character(q$layers[[1]]$aes_params$colour), "blue")
   expect_equal(q$layers[[1]]$aes_params$size, 0.4)
 
@@ -73,7 +73,7 @@ test_that("layer parameters are correct", {
   expect_equal(deparse(r$layers[[1]]$mapping$x), "~x")
   expect_equal(deparse(r$layers[[1]]$mapping$y), "~y")
   expect_equal(deparse(r$layers[[1]]$mapping$group), "~group")
-  expect_equal(deparse(r$layers[[1]]$mapping$fill), "~map_df[, values]")
+  expect_equal(deparse(r$layers[[1]]$mapping$fill), "~values")
   expect_equal(as.character(r$layers[[1]]$aes_params$colour), "black")
   expect_equal(r$layers[[1]]$aes_params$size, 0.8)
 


### PR DESCRIPTION
This change fixes an issue in which `plot_usmap` failed if the provided data had a column named `"values"`.

Verification example:
```
library(usmap)

df <- data.frame(fips = fips(), values = 1:length(fips()))

df2 <- df
names(df2) <- c("fips", "X")

plot_usmap(data = df)
plot_usmap(data = df2, values = "X")
```

fixes #48 