### PR TITLE
`usmap_transform` improvements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # usmap 0.5.2.9999
 
 ### New Features
+* Add `input_names` and `output_names` parameters to `usmap_transform`, see [Issue #33](https://github.com/pdil/usmap/issues/33).
 * Add `sortAndRemoveDuplicates` parameter to `fips_info`, see [Issue #47](https://github.com/pdil/usmap/issues/47).
   * The default (`FALSE`) value changes existing behavior, to retain existing behavior, change the parameter value to `TRUE`.
 

--- a/R/transform.R
+++ b/R/transform.R
@@ -9,6 +9,14 @@
 #'   represents latitude. The names of the data frame column do not matter,
 #'   just that the order of the columns is kept intact.
 #'
+#' @param input_names A character vector of length two which specifies the
+#'   longitude and latitude columns of the input data (the ones that should be
+#'   transformed), respectively. Defaults to `c("lon", "lat")`.
+#'
+#' @param output_names A character vector of length two which specifies the
+#'   longitude and latitude columns of the output data (after transformation),
+#'   respectively. Defaults to `c("x", "y")`.
+#'
 #' @return A data frame containing the transformed coordinates from the
 #'   input data frame with the Albers Equal Area projection applied. The
 #'   transformed columns will be appended to the data frame so that all
@@ -29,7 +37,7 @@
 #'
 #' plot_usmap() + geom_point(
 #'   data = transformed_data,
-#'   aes(x = lon.1, y = lat.1, size = pop),
+#'   aes(x = x, y = y, size = pop),
 #'   color = "red", alpha = 0.5
 #' )
 #'

--- a/man/usmap_transform.Rd
+++ b/man/usmap_transform.Rd
@@ -5,9 +5,17 @@
 \alias{usmap_transform.data.frame}
 \title{Convert coordinate date frame to usmap projection}
 \usage{
-usmap_transform(data)
+usmap_transform(
+  data,
+  input_names = c("lon", "lat"),
+  output_names = c("x", "y")
+)
 
-\method{usmap_transform}{data.frame}(data)
+\method{usmap_transform}{data.frame}(
+  data,
+  input_names = c("lon", "lat"),
+  output_names = c("x", "y")
+)
 }
 \arguments{
 \item{data}{A data frame containing coordinates in a two column format

--- a/man/usmap_transform.Rd
+++ b/man/usmap_transform.Rd
@@ -22,6 +22,14 @@ usmap_transform(
 where the first column represents longitude and the second data frame
 represents latitude. The names of the data frame column do not matter,
 just that the order of the columns is kept intact.}
+
+\item{input_names}{A character vector of length two which specifies the
+longitude and latitude columns of the input data (the ones that should be
+transformed), respectively. Defaults to \code{c("lon", "lat")}.}
+
+\item{output_names}{A character vector of length two which specifies the
+longitude and latitude columns of the output data (after transformation),
+respectively. Defaults to \code{c("x", "y")}.}
 }
 \value{
 A data frame containing the transformed coordinates from the
@@ -49,7 +57,7 @@ library(ggplot2)
 
 plot_usmap() + geom_point(
   data = transformed_data,
-  aes(x = lon.1, y = lat.1, size = pop),
+  aes(x = x, y = y, size = pop),
   color = "red", alpha = 0.5
 )
 

--- a/tests/testthat/test-transform.R
+++ b/tests/testthat/test-transform.R
@@ -9,8 +9,8 @@ test_that("data frame with AK and HI points is transformed", {
   result <- data.frame(
     lon = c(-74.01, -95.36, -118.24, -87.65, -134.42, -157.86),
     lat = c(40.71, 29.76, 34.05, 41.85, 58.30, 21.31),
-    lon.1 = c(2147110.0, 451625.4, -1672256.6, 1018522.4, -769682.2, -453273.9),
-    lat.1 = c(-133148.4, -1677546.4, -1035039.5, -273371.4, -2078025.3, -2051494.0)
+    x = c(2147110.0, 451625.4, -1672256.6, 1018522.4, -769682.2, -453273.9),
+    y = c(-133148.4, -1677546.4, -1035039.5, -273371.4, -2078025.3, -2051494.0)
   )
 
   expect_equal(usmap_transform(data), result, tolerance = 1e-05)
@@ -25,8 +25,8 @@ test_that("data frame with AK points is transformed", {
   result <- data.frame(
     lon = c(-74.01, -95.36, -118.24, -87.65, -134.42),
     lat = c(40.71, 29.76, 34.05, 41.85, 58.30),
-    lon.1 = c(2147110.0, 451625.4, -1672256.6, 1018522.4, -769682.2),
-    lat.1 = c(-133148.4, -1677546.4, -1035039.5, -273371.4, -2078025.3)
+    x = c(2147110.0, 451625.4, -1672256.6, 1018522.4, -769682.2),
+    y = c(-133148.4, -1677546.4, -1035039.5, -273371.4, -2078025.3)
   )
 
   expect_equal(usmap_transform(data), result, tolerance = 1e-05)
@@ -41,8 +41,8 @@ test_that("data frame with HI points is transformed", {
   result <- data.frame(
     lon = c(-74.01, -95.36, -118.24, -87.65, -157.86),
     lat = c(40.71, 29.76, 34.05, 41.85, 21.31),
-    lon.1 = c(2147110.0, 451625.4, -1672256.6, 1018522.4, -453273.9),
-    lat.1 = c(-133148.4, -1677546.4, -1035039.5, -273371.4, -2051494.0)
+    x = c(2147110.0, 451625.4, -1672256.6, 1018522.4, -453273.9),
+    y = c(-133148.4, -1677546.4, -1035039.5, -273371.4, -2051494.0)
   )
 
   expect_equal(usmap_transform(data), result, tolerance = 1e-05)
@@ -57,8 +57,8 @@ test_that("data frame with no AK or HI points is transformed", {
   result <- data.frame(
     lon = c(-74.01, -95.36, -118.24, -87.65),
     lat = c(40.71, 29.76, 34.05, 41.85),
-    lon.1 = c(2147110.0, 451625.4, -1672256.6, 1018522.4),
-    lat.1 = c(-133148.4, -1677546.4, -1035039.5, -273371.4)
+    x = c(2147110.0, 451625.4, -1672256.6, 1018522.4),
+    y = c(-133148.4, -1677546.4, -1035039.5, -273371.4)
   )
 
   expect_equal(usmap_transform(data), result, tolerance = 1e-05)
@@ -71,6 +71,17 @@ test_that("error occurs for data with less than 2 columns", {
 
   expect_error(usmap_transform(invalid_data))
   expect_error(usmap_transform(data.frame()))
+})
+
+test_that("error occurs for invalid input and output names", {
+  data <- data.frame(
+    lon = c(-74.01, -95.36, -118.24, -87.65),
+    lat = c(40.71, 29.76, 34.05, 41.85)
+  )
+
+  expect_error(usmap_transform(data, input_names = c("longitude")))
+  expect_error(usmap_transform(data, input_names = c("longitude", "latitude")))
+  expect_error(usmap_transform(data, output_names = c("x")))
 })
 
 test_that("error occurs for data with non-numeric columns", {

--- a/vignettes/advanced-mapping.R
+++ b/vignettes/advanced-mapping.R
@@ -21,7 +21,7 @@ usmap::plot_usmap("counties",
                   labels = TRUE, label_color = "blue",
                   fill = "yellow", alpha = 0.25, color = "orange", size = 2)
 
-## -----------------------------------------------------------------------------
+## ---- warning=FALSE-----------------------------------------------------------
 usmap::usmap_crs()@projargs
 
 ## ---- fig.align='center', fig.width=8, fig.height=5, message=FALSE, warning=FALSE----
@@ -31,7 +31,7 @@ library(ggplot2)
 eq_transformed <- usmap_transform(earthquakes)
 
 plot_usmap() +
-  geom_point(data = eq_transformed, aes(x = lon.1, y = lat.1, size = mag),
+  geom_point(data = eq_transformed, aes(x = x, y = y, size = mag),
              color = "red", alpha = 0.25) +
   labs(title = "US Earthquakes",
        subtitle = "Source: USGS, Jan 1 to Jun 30 2019",
@@ -46,13 +46,13 @@ cities_t <- usmap_transform(citypop)
 
 plot_usmap(fill = "yellow", alpha = 0.25) +
   ggrepel::geom_label_repel(data = cities_t,
-             aes(x = lon.1, y = lat.1, label = most_populous_city),
+             aes(x = x, y = y, label = most_populous_city),
              size = 3, alpha = 0.8,
              label.r = unit(0.5, "lines"), label.size = 0.5,
              segment.color = "red", segment.size = 1,
              seed = 1002) +
   geom_point(data = cities_t,
-             aes(x = lon.1, y = lat.1, size = city_pop),
+             aes(x = x, y = y, size = city_pop),
              color = "purple", alpha = 0.5) +
   scale_size_continuous(range = c(1, 16),
                         label = scales::comma) +

--- a/vignettes/advanced-mapping.Rmd
+++ b/vignettes/advanced-mapping.Rmd
@@ -69,7 +69,7 @@ This is convenient for plotting location-specific data and values using `ggplot2
 #### Projection
 
 The projection used by `usmap` can also be accessed by using `usmap_crs()`:
-```{r}
+```{r, warning=FALSE}
 usmap::usmap_crs()@projargs
 ```
 
@@ -86,7 +86,7 @@ library(ggplot2)
 eq_transformed <- usmap_transform(earthquakes)
 
 plot_usmap() +
-  geom_point(data = eq_transformed, aes(x = lon.1, y = lat.1, size = mag),
+  geom_point(data = eq_transformed, aes(x = x, y = y, size = mag),
              color = "red", alpha = 0.25) +
   labs(title = "US Earthquakes",
        subtitle = "Source: USGS, Jan 1 to Jun 30 2019",
@@ -105,13 +105,13 @@ cities_t <- usmap_transform(citypop)
 
 plot_usmap(fill = "yellow", alpha = 0.25) +
   ggrepel::geom_label_repel(data = cities_t,
-             aes(x = lon.1, y = lat.1, label = most_populous_city),
+             aes(x = x, y = y, label = most_populous_city),
              size = 3, alpha = 0.8,
              label.r = unit(0.5, "lines"), label.size = 0.5,
              segment.color = "red", segment.size = 1,
              seed = 1002) +
   geom_point(data = cities_t,
-             aes(x = lon.1, y = lat.1, size = city_pop),
+             aes(x = x, y = y, size = city_pop),
              color = "purple", alpha = 0.5) +
   scale_size_continuous(range = c(1, 16),
                         label = scales::comma) +

--- a/vignettes/advanced-mapping.html
+++ b/vignettes/advanced-mapping.html
@@ -184,9 +184,7 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <h4>Projection</h4>
 <p>The projection used by <code>usmap</code> can also be accessed by using <code>usmap_crs()</code>:</p>
 <div class="sourceCode" id="cb5"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a>usmap<span class="sc">::</span><span class="fu">usmap_crs</span>()<span class="sc">@</span>projargs</span>
-<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a><span class="co">#&gt; Warning in showSRID(uprojargs, format = &quot;PROJ&quot;, multiline = &quot;NO&quot;, prefer_proj =</span></span>
-<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a><span class="co">#&gt; prefer_proj): Discarded datum unknown in Proj4 definition</span></span>
-<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a><span class="co">#&gt; [1] &quot;+proj=laea +lat_0=45 +lon_0=-100 +x_0=0 +y_0=0 +ellps=sphere +units=m +no_defs&quot;</span></span></code></pre></div>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a><span class="co">#&gt; [1] &quot;+proj=laea +lat_0=45 +lon_0=-100 +x_0=0 +y_0=0 +ellps=sphere +units=m +no_defs&quot;</span></span></code></pre></div>
 <p>A convenience method called <code>usmap_transform</code> is provided that transforms a <code>data.frame</code> containing longitude/latitude columns to use this projection. (Currently, only <code>data.frame</code>s are supported. Other structures may be supported in the future.)</p>
 </div>
 <div id="example-earthquakes" class="section level4">
@@ -198,7 +196,7 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a>eq_transformed <span class="ot">&lt;-</span> <span class="fu">usmap_transform</span>(earthquakes)</span>
 <span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a><span class="fu">plot_usmap</span>() <span class="sc">+</span></span>
-<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">geom_point</span>(<span class="at">data =</span> eq_transformed, <span class="fu">aes</span>(<span class="at">x =</span> lon<span class="fl">.1</span>, <span class="at">y =</span> lat<span class="fl">.1</span>, <span class="at">size =</span> mag),</span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">geom_point</span>(<span class="at">data =</span> eq_transformed, <span class="fu">aes</span>(<span class="at">x =</span> x, <span class="at">y =</span> y, <span class="at">size =</span> mag),</span>
 <span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a>             <span class="at">color =</span> <span class="st">&quot;red&quot;</span>, <span class="at">alpha =</span> <span class="fl">0.25</span>) <span class="sc">+</span></span>
 <span id="cb6-9"><a href="#cb6-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">labs</span>(<span class="at">title =</span> <span class="st">&quot;US Earthquakes&quot;</span>,</span>
 <span id="cb6-10"><a href="#cb6-10" aria-hidden="true" tabindex="-1"></a>       <span class="at">subtitle =</span> <span class="st">&quot;Source: USGS, Jan 1 to Jun 30 2019&quot;</span>,</span>
@@ -216,13 +214,13 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a><span class="fu">plot_usmap</span>(<span class="at">fill =</span> <span class="st">&quot;yellow&quot;</span>, <span class="at">alpha =</span> <span class="fl">0.25</span>) <span class="sc">+</span></span>
 <span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a>  ggrepel<span class="sc">::</span><span class="fu">geom_label_repel</span>(<span class="at">data =</span> cities_t,</span>
-<span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a>             <span class="fu">aes</span>(<span class="at">x =</span> lon<span class="fl">.1</span>, <span class="at">y =</span> lat<span class="fl">.1</span>, <span class="at">label =</span> most_populous_city),</span>
+<span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a>             <span class="fu">aes</span>(<span class="at">x =</span> x, <span class="at">y =</span> y, <span class="at">label =</span> most_populous_city),</span>
 <span id="cb7-9"><a href="#cb7-9" aria-hidden="true" tabindex="-1"></a>             <span class="at">size =</span> <span class="dv">3</span>, <span class="at">alpha =</span> <span class="fl">0.8</span>,</span>
 <span id="cb7-10"><a href="#cb7-10" aria-hidden="true" tabindex="-1"></a>             <span class="at">label.r =</span> <span class="fu">unit</span>(<span class="fl">0.5</span>, <span class="st">&quot;lines&quot;</span>), <span class="at">label.size =</span> <span class="fl">0.5</span>,</span>
 <span id="cb7-11"><a href="#cb7-11" aria-hidden="true" tabindex="-1"></a>             <span class="at">segment.color =</span> <span class="st">&quot;red&quot;</span>, <span class="at">segment.size =</span> <span class="dv">1</span>,</span>
 <span id="cb7-12"><a href="#cb7-12" aria-hidden="true" tabindex="-1"></a>             <span class="at">seed =</span> <span class="dv">1002</span>) <span class="sc">+</span></span>
 <span id="cb7-13"><a href="#cb7-13" aria-hidden="true" tabindex="-1"></a>  <span class="fu">geom_point</span>(<span class="at">data =</span> cities_t,</span>
-<span id="cb7-14"><a href="#cb7-14" aria-hidden="true" tabindex="-1"></a>             <span class="fu">aes</span>(<span class="at">x =</span> lon<span class="fl">.1</span>, <span class="at">y =</span> lat<span class="fl">.1</span>, <span class="at">size =</span> city_pop),</span>
+<span id="cb7-14"><a href="#cb7-14" aria-hidden="true" tabindex="-1"></a>             <span class="fu">aes</span>(<span class="at">x =</span> x, <span class="at">y =</span> y, <span class="at">size =</span> city_pop),</span>
 <span id="cb7-15"><a href="#cb7-15" aria-hidden="true" tabindex="-1"></a>             <span class="at">color =</span> <span class="st">&quot;purple&quot;</span>, <span class="at">alpha =</span> <span class="fl">0.5</span>) <span class="sc">+</span></span>
 <span id="cb7-16"><a href="#cb7-16" aria-hidden="true" tabindex="-1"></a>  <span class="fu">scale_size_continuous</span>(<span class="at">range =</span> <span class="fu">c</span>(<span class="dv">1</span>, <span class="dv">16</span>),</span>
 <span id="cb7-17"><a href="#cb7-17" aria-hidden="true" tabindex="-1"></a>                        <span class="at">label =</span> scales<span class="sc">::</span>comma) <span class="sc">+</span></span>


### PR DESCRIPTION
* Added `input_names` and `output_names` parameters to `usmap_transform`
* Standardized output columns to `x` and `y` instead of using obscure `.1` suffixes

fixes #33 