### PR TITLE
Resolve failing R CMD check in 0.6.0

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -10,36 +10,20 @@ name: test-coverage
 
 jobs:
   test-coverage:
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@master
-
-      - uses: r-lib/actions/setup-pandoc@master
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        uses: actions/cache@v2
+      - uses: r-lib/actions/setup-r@v1
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          use-public-rspm: true
 
-      - name: Install dependencies
-        run: |
-          install.packages(c("remotes"))
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("covr")
-        shell: Rscript {0}
+      - uses: r-lib/actions/setup-r-dependencies@v1
+        with:
+          extra-packages: covr
 
       - name: Test coverage
         run: covr::codecov()

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # usmap 0.6.0.9999
 
+### Bug Fixes
+* Fixes failing `plot_usmap` tests, see [Issue #58](https://github.com/pdil/usmap/issues/58).
+
 # usmap 0.6.0
 Released Sunday, February 27, 2022.
 

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -134,13 +134,6 @@ test_that("layer parameters are correct", {
   expect_equal(deparse(v$layers[[2]]$mapping$label), "~abbr")
 })
 
-test_that("singular regions can be used", {
-  expect_equal(plot_usmap(regions = "states")$layers,
-               plot_usmap(regions = "state")$layers)
-  expect_equal(plot_usmap(regions = "counties")$layers,
-               plot_usmap(regions = "county")$layers)
-})
-
 test_that("warning occurs for unnecessary fill argument", {
   expect_warning(plot_usmap(data = example_data, fill = "red"))
 })


### PR DESCRIPTION
* Remove outdated `plot_usmap` tests causing failures.

fixes #58 