### PR TITLE
Add lintr configuration file

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,6 @@
+linters: linters_with_defaults(
+  line_length_linter(120),
+)
+exclusions: list(
+  "revdep"
+)


### PR DESCRIPTION
* Add `lintr` configuration file `.lintr`
* Should reduce linting warnings and provide more fine-tuned linting configuration in the future