### PR TITLE
replace retiring packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,12 +22,11 @@ Suggests:
     ggplot2,
     ggrepel,
     knitr,
-    maptools,
     proto,
-    rgdal,
     rmarkdown,
     scales,
     sp,
+    sf,
     stringr,
     testthat
 RoxygenNote: 7.2.2

--- a/R/transform.R
+++ b/R/transform.R
@@ -47,22 +47,27 @@ usmap_transform <- function(data,
                             input_names = c("lon", "lat"),
                             output_names = c("x", "y")) {
   # check for maptools
-  if (!requireNamespace("maptools", quietly = TRUE)) {
-    stop("`maptools` must be installed to use `usmap_transform`.
-         Use: install.packages(\"maptools\") and try again.")
-  }
+#  if (!requireNamespace("maptools", quietly = TRUE)) {
+#    stop("`maptools` must be installed to use `usmap_transform`.
+#         Use: install.packages(\"maptools\") and try again.")
+#  }
 
   # check for sp
   if (!requireNamespace("sp", quietly = TRUE)) {
     stop("`sp` must be installed to use `usmap_transform`.
          Use: install.packages(\"sp\") and try again.")
   }
+  if (sp::get_evolution_status() != 2L) sp::set_evolution_status(2L)
+  if (!requireNamespace("sf", quietly = TRUE)) {
+    stop("`sf` must be installed to use `usmap_transform`.
+         Use: install.packages(\"sf\") and try again.")
+  }
 
   # check for rgdal
-  if (!requireNamespace("rgdal", quietly = TRUE)) {
-    stop("`rgdal` must be installed to use `usmap_transform`.
-         Use: install.packages(\"rgdal\") and try again.")
-  }
+#  if (!requireNamespace("rgdal", quietly = TRUE)) {
+#    stop("`rgdal` must be installed to use `usmap_transform`.
+#         Use: install.packages(\"rgdal\") and try again.")
+#  }
 
   UseMethod("usmap_transform", data)
 }
@@ -131,13 +136,13 @@ usmap_transform.data.frame <- function(data,
   ]
 
   if (length(alaska) > 0) {
-    alaska <- maptools::elide(
+    alaska <- sp::elide(
       alaska,
       rotate = -50,
       scale = max(apply(ak_bbox, 1, diff)) / 2.3,
       bb = ak_bbox
     )
-    alaska <- maptools::elide(alaska, shift = c(-1298669, -3018809))
+    alaska <- sp::elide(alaska, shift = c(-1298669, -3018809))
     sp::proj4string(alaska) <- usmap_crs()
     names(alaska) <- names(transformed)
   }
@@ -163,12 +168,12 @@ usmap_transform.data.frame <- function(data,
   ]
 
   if (length(hawaii) > 0) {
-    hawaii <- maptools::elide(
+    hawaii <- sp::elide(
       hawaii,
       rotate = -35,
       bb = hi_bbox
     )
-    hawaii <- maptools::elide(hawaii, shift = c(5400000, -1400000))
+    hawaii <- sp::elide(hawaii, shift = c(5400000, -1400000))
     sp::proj4string(hawaii) <- usmap_crs()
     names(hawaii) <- names(transformed)
   }
@@ -209,6 +214,11 @@ usmap_crs <- function() {
          Use: install.packages(\"sp\") and try again.")
   }
 
+  if (sp::get_evolution_status() != 2L) sp::set_evolution_status(2L)
+  if (!requireNamespace("sf", quietly = TRUE)) {
+    stop("`sf` must be installed to use `usmap_transform`.
+         Use: install.packages(\"sf\") and try again.")
+  }
   sp::CRS(paste("+proj=laea +lat_0=45 +lon_0=-100 +x_0=0 +y_0=0",
                 "+a=6370997 +b=6370997 +units=m +no_defs"))
 }


### PR DESCRIPTION
This relates to #57 and removes **rgdal** and **maptools**. In the `add_elide` branch of my fork of **sp** https://github.com/rsbivand/sp/tree/add_elide, `elide()` methods are moved from **maptools** to **sp**. Note that CI will fail without the stated pre-release version of **sp**. With `sp::set_evolution_status(2L)`, *'sp** is set to coerce to `"sf"` and use `sf::st_transform()` to project objects to planar. Ucertain when **sp** with `elide()` may be released.

closes #57 