### PR TITLE
Fix link to introduction vignette

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
     <a href="https://github.com/pdil/usmap">GitHub</a> •
     <a href="https://cran.r-project.org/package=usmap">CRAN</a> •
     <a href="https://cran.r-project.org/web/packages/usmap/usmap.pdf">Docs</a> •
-    <a href="https://cran.r-project.org/web/packages/usmap/vignettes/introduction.html">Introduction</a>
+    <a href="https://cran.r-project.org/web/packages/usmap/vignettes/usmap1.html">Introduction</a>
     
     <br><br>
     


### PR DESCRIPTION
* Vignettes were renamed in `usmap v0.7.0` so the "Introduction" link wasn't working.
* This change updates the link to the new URL.