### PR TITLE
Implement usmapdata 0.2.2 updates

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,5 +1,5 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+
 on:
   push:
     branches: [main, master]
@@ -29,7 +29,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -47,3 +47,4 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/.github/workflows/lintr.yml
+++ b/.github/workflows/lintr.yml
@@ -1,7 +1,3 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
 # lintr provides static code analysis for R.
 # It checks for adherence to a given style,
 # identifying syntax errors and possible semantic issues,
@@ -29,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
@@ -45,7 +41,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: lintr-results.sarif
           wait-for-processing: true

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,5 +1,5 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+
 on:
   push:
     branches: [main, master]
@@ -15,7 +15,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -31,7 +31,7 @@ jobs:
           covr::codecov(
             quiet = FALSE,
             clean = FALSE,
-            install_path = file.path(Sys.getenv("RUNNER_TEMP"), "package")
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
           )
         shell: Rscript {0}
 
@@ -39,12 +39,12 @@ jobs:
         if: always()
         run: |
           ## --------------------------------------------------------------------
-          find ${{ runner.temp }}/package -name 'testthat.Rout*' -exec cat '{}' \; || true
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
         shell: bash
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Obtain United States map data frames of varying region types (e.g. 
     state). The map data frames include Alaska and Hawaii conveniently placed to the
     bottom left, as they appear in most maps of the US. Convenience functions for plotting
     choropleths, visualizing spatial data, and working with FIPS codes are also provided.
-Authors@R: person("Paolo", "Di Lorenzo", email = "dilorenzo@hey.com", role = c("aut", "cre"))
+Authors@R: person("Paolo", "Di Lorenzo", email = "dilorenzo@hey.com", role = c("aut", "cph", "cre"))
 Depends:
     R (>= 3.5.0)
 License: GPL (>= 3)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ URL: https://usmap.dev
 BugReports: https://github.com/pdil/usmap/issues
 Imports:
     rlang,
-    usmapdata (>= 0.2.0)
+    usmapdata (>= 0.2.2)
 Suggests:
     covr,
     ggplot2 (>= 3.5.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,12 @@
 ### Bug Fixes
 * Replace `size` with `linewidth` in `plot_usmap()` documentation, see [Issue #89](https://github.com/pdil/usmap/issues/89).
 
+### Technical Changes
+* Internal `usmapdata` functions are used for data transformation (i.e. `usmap_transform()`) values for consistency.
+  * This allows the same values used to create the map to be used when transforming external data.
+  * Values will now only have to be updated in one place.
+  * `usmapdata v0.2.2` is now a required dependency because of this change.
+
 # usmap 0.7.0
 Released Saturday, January 20, 2024.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ### Improvements
 * Add citation information to README, see [Issue #86](https://github.com/pdil/usmap/issues/86).
-* Update map theme to work with new legend behavior in [ggplot2 v3.5.0](https://www.tidyverse.org/blog/2024/02/ggplot2-3-5-0-legends/#placement).
+* Update map theme to work with new legend behavior in [ggplot2 3.5.0](https://www.tidyverse.org/blog/2024/02/ggplot2-3-5-0-legends/#placement).
 
 ### Bug Fixes
 * Replace `size` with `linewidth` in `plot_usmap()` documentation, see [Issue #89](https://github.com/pdil/usmap/issues/89).
@@ -11,7 +11,7 @@
 * Internal `usmapdata` functions are used for data transformation (i.e. `usmap_transform()`) values for consistency.
   * This allows the same values used to create the map to be used when transforming external data.
   * Values will now only have to be updated in one place.
-  * `usmapdata v0.2.2` is now a required dependency because of this change.
+  * `usmapdata 0.2.2` is now a required dependency because of this change.
 
 # usmap 0.7.0
 Released Saturday, January 20, 2024.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ### Improvements
 * Add citation information to README, see [Issue #86](https://github.com/pdil/usmap/issues/86).
-* Update map theme to work with new legend behavior in [ggplot2 3.5.0](https://www.tidyverse.org/blog/2024/02/ggplot2-3-5-0-legends/#placement).
+* Update map theme to work with new legend behavior in [ggplot2 3.5.0](https://www.tidyverse.org/blog/2024/02/ggplot2-3-5-0-legends/#placement).'
 
 ### Bug Fixes
 * Replace `size` with `linewidth` in `plot_usmap()` documentation, see [Issue #89](https://github.com/pdil/usmap/issues/89).
@@ -12,6 +12,9 @@
   * This allows the same values used to create the map to be used when transforming external data.
   * Values will now only have to be updated in one place.
   * `usmapdata 0.2.2` is now a required dependency because of this change.
+* Continue `sf`-based map data file migration.
+  * Usage of the `as_sf` parameter in `usmapdata` function calls has been removed.
+  * The parameter will be removed from `usmapdata` functions in the future.
 
 # usmap 0.7.0
 Released Saturday, January 20, 2024.

--- a/R/fips.R
+++ b/R/fips.R
@@ -54,14 +54,14 @@
 #' @export
 fips <- function(state, county = c()) {
   if (missing(state) && missing(county)) {
-    return(usmapdata::fips_data(as_sf = TRUE)$fips)
+    return(usmapdata::fips_data()$fips)
   }
 
   state_ <- tolower(state)
   county_ <- tolower(county)
 
   if (length(county_) == 0) {
-    df <- usmapdata::fips_data(as_sf = TRUE)
+    df <- usmapdata::fips_data()
     abbr <- tolower(df$abbr)
     full <- tolower(df$full)
     fips2 <- c(df$fips, df$fips)
@@ -74,7 +74,7 @@ fips <- function(state, county = c()) {
       stop("`county` parameter cannot be used with multiple states.")
     }
 
-    df <- usmapdata::fips_data("counties", as_sf = TRUE)
+    df <- usmapdata::fips_data("counties")
     name <- tolower(df$county)
     state_abbr <- tolower(df$abbr)
     state_full <- tolower(df$full)
@@ -174,10 +174,10 @@ fips_info.character <- function(fips, sortAndRemoveDuplicates = FALSE) {
 #' @keywords internal
 get_fips_info <- function(fips, sortAndRemoveDuplicates) {
   if (all(nchar(fips) == 2)) {
-    df <- usmapdata::fips_data(as_sf = TRUE)
+    df <- usmapdata::fips_data()
     columns <- c("abbr", "fips", "full")
   } else if (all(nchar(fips) == 5)) {
-    df <- usmapdata::fips_data("counties", as_sf = TRUE)
+    df <- usmapdata::fips_data("counties")
     columns <- c("full", "abbr", "county", "fips")
   }
 

--- a/R/plot-map.R
+++ b/R/plot-map.R
@@ -109,7 +109,7 @@ plot_usmap <- function(regions = c("states", "state", "counties", "county"),
     if (regions == "state") regions <- "states"
     else if (regions == "county") regions <- "counties"
 
-    centroid_labels <- usmapdata::centroid_labels(regions, as_sf = TRUE)
+    centroid_labels <- usmapdata::centroid_labels(regions)
 
     if (length(include) > 0) {
       centroid_labels <- centroid_labels[

--- a/R/transform.R
+++ b/R/transform.R
@@ -118,44 +118,14 @@ perform_transform <- function(data, ...) {
   sf::st_agr(transformed) <- "constant"
 
   # Transform Alaska points
-  ak_bbox <- sf::st_as_sfc(
-    sf::st_bbox(
-      c(
-        xmin = -4377000,
-        xmax = -1519000,
-        ymin = 1466000,
-        ymax = 3914000
-      ),
-      crs = usmap_crs()
-    )
-  )
+  ak_bbox <- usmapdata:::alaska_bbox()
   alaska <- sf::st_intersection(transformed, ak_bbox)
-
-  if (nrow(alaska) > 0) {
-    sf::st_geometry(alaska) <- sf::st_geometry(alaska) * usmapdata:::transform2D(-50, 1 / 2)
-    sf::st_geometry(alaska) <- sf::st_geometry(alaska) + c(3e5, -2e6)
-    sf::st_crs(alaska) <- usmap_crs()
-  }
+  alaska <- usmapdata:::transform_alaska(alaska)
 
   # Transform Hawaii points
-  hi_bbox <- sf::st_as_sfc(
-    sf::st_bbox(
-      c(
-        xmin = -5750000,
-        xmax = -5450000,
-        ymin = -1050000,
-        ymax = -441000
-      ),
-      crs = usmap_crs()
-    )
-  )
+  hi_bbox <- usmapdata:::hawaii_bbox()
   hawaii <- sf::st_intersection(transformed, hi_bbox)
-
-  if (nrow(hawaii) > 0) {
-    sf::st_geometry(hawaii) <- sf::st_geometry(hawaii) * usmapdata:::transform2D(-35)
-    sf::st_geometry(hawaii) <- sf::st_geometry(hawaii) + c(3.6e6, 1.8e6)
-    sf::st_crs(hawaii) <- usmap_crs()
-  }
+  hawaii <- usmapdata:::transform_hawaii(hawaii)
 
   # Re-combine all points
   transformed_excl_ak <- sf::st_difference(transformed, ak_bbox)
@@ -177,5 +147,5 @@ perform_transform <- function(data, ...) {
 #'
 #' @export
 usmap_crs <- function() {
-  sf::st_crs(9311)
+  usmapdata:::ea_crs()
 }

--- a/R/usmap.R
+++ b/R/usmap.R
@@ -103,5 +103,5 @@
 us_map <- function(regions = c("states", "state", "counties", "county"),
                    include = c(),
                    exclude = c()) {
-  usmapdata::us_map(regions = regions, include = include, exclude = exclude, as_sf = TRUE)
+  usmapdata::us_map(regions = regions, include = include, exclude = exclude)
 }


### PR DESCRIPTION
* Use `usmapdata 0.2.2` functions in `usmap_transform()`
* Removed references to `as_sf` parameter in `usmapdata` function calls.
* Updated GitHub Actions workflows to resolve deprecation warnings (see related: [pdil/usmapdata/23](https://github.com/pdil/usmapdata/pull/27))